### PR TITLE
supervisord fails for python dokku apps

### DIFF
--- a/post-release
+++ b/post-release
@@ -6,7 +6,6 @@ read -d '' runner <<'EOF'
 
 set -e
 export HOME=/app
-for file in \$HOME/.profile.d/*; do source \$file; done
 hash -r
 cd \$HOME
 
@@ -21,7 +20,7 @@ while read line || [ -n "\$line" ]; do
   command=\${line#*: }
   cat << CONF >> supervisord.conf
 [program:\${name}]
-command=sh -c "\${command}"
+command=/exec sh -c "\${command}"
 autostart=true
 autorestart=true
 stopsignal=QUIT


### PR DESCRIPTION
For dokku python apps, virtualenv is used to setup a new python and module paths. The new python may be a different version than apt-get's supervisord (which has a hardcoded shebang to `/usr/bin/python`) which will result in the error: `ImportError: cannot import name MAXREPEAT`. Also, virtualenv's python module paths does not include the files required for apt-get installed supervisord, so execution will fail. 

The proposed solution is to modify `post-commit` to NOT setup the app's environment when executing supervisord. Instead, each command is modified to pass through `/exec` so that the correct environment is set.

I've attached a pull request. Thanks!
