### PR TITLE
`$IMAGE` is now set from `$APP` (app name)

### DIFF
--- a/post-release
+++ b/post-release
@@ -1,5 +1,5 @@
 #!/bin/bash
-APP="$1"; IMAGE="$2"
+APP="$1"; IMAGE="app/$1"
 
 read -d '' runner <<'EOF'
 #!/bin/bash


### PR DESCRIPTION
Changes introduced in dokku (28de3ecaa3231a223f83fd8d03f373308673bc40)
now remove the need to specify _both_ an app name and image name for
base dokku commands like: dokku release appname app/appname, which is
now: dokku release appname. Therefore, this change does not rely on
`$IMAGE` being passed to this plugin but rather sets it from the
appname (since by convention, `$IMAGE = 'app/appname'`).

This fixes a bug that prevents dokku-supervisord from being used with the latest dokku. However, it is backwards compatible with old versions of dokku.
