### PR TITLE
Use install hook for supervisord installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ will restart crashed applications.
 ## Installation
 
 ```sh
-git clone https://github.com/statianzo/dokku-supervisord.git /var/lib/dokku/plugins/dokku-supervisord
+git clone https://github.com/statianzo/dokku-supervisord.git /var/lib/dokku/plugins/supervisord
+dokku plugins-install
 ```
 
 All future deployments will use supervisord to start all processes.

--- a/install
+++ b/install
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Build docker image
+docker build -q=true -t yuvadm/supervisord github.com/yuvadm/dokku-supervisord-dockerfiles

--- a/post-release
+++ b/post-release
@@ -38,7 +38,7 @@ set -e
 
 echo "-----> Injecting Supervisor ..."
 
-id=$(echo "$runner" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /start && apt-get update && apt-get install -y supervisor && apt-get clean")
+id=$(echo "$runner" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /start")
 docker attach $id
 test $(docker wait $id) -eq 0
 docker commit $id $IMAGE > /dev/null


### PR DESCRIPTION
Current implementation tries to `apt-get install supervisor` on each push, which is obviously redundant. Supervisord should be installed using the `install` hook (via `dokku plugins-install`) and then run through docker.

This change should use a proper `install` hook using a minimal repo with a Dockerfile for supervisord (you can see the repo at https://github.com/yuvadm/dokku-supervisord-dockerfiles).

It _should_ be working, but I'm still stuck on a minor bug that makes things not work, probably due to my inexperience with docker.

Any tips on how to complete this task?

(Testing this PR can be easily done by amending the `git clone` command to run from my fork - `yuvadm`).
