### PR TITLE
Use Ruby/YAML to parse the Procfile

### DIFF
--- a/post-release
+++ b/post-release
@@ -15,10 +15,13 @@ loglevel=debug
 nodaemon=true
 CONF
 
-while read line && [[ "\$line" =~ ^([A-Za-z0-9_-]+):\s*(.+)$ ]]; do
-  name=\${line%%:*}
-  command=\${line#*: }
-  cat << CONF >> supervisord.conf
+while read line
+do
+  if [[ "\$line" =~ ^([A-Za-z0-9_-]+):\s*(.+)$ ]]
+  then
+    name=\${line%%:*}
+    command=\${line#*: }
+    cat << CONF >> supervisord.conf
 [program:\${name}]
 command=/exec sh -c "\${command}"
 autostart=true
@@ -26,7 +29,7 @@ autorestart=true
 stopsignal=QUIT
 
 CONF
-
+  fi
 done < "Procfile"
 
 


### PR DESCRIPTION
I have comments in my Procfile and they brake the bash string manipulation techniques used in the post-release hook ([relevant lines](https://github.com/statianzo/dokku-supervisord/blob/master/post-release#L19-L20)).

I know it's tempting to just "fix" them to take comments into account, but my advice is to just use a real YAML parser (as [is done in buildstep itself](https://github.com/progrium/buildstep/blob/master/stack/builder#L60-L92)).

Probably the best option is to just use Ruby which is already bundled inside the builder image (I can help if needed). :)
