### PR TITLE
make /start executable

### DIFF
--- a/post-release
+++ b/post-release
@@ -48,6 +48,7 @@ fi
 echo "-----> Injecting Supervisor ..."
 
 CMD="cat > /start && \
+  chmod +x /start && \
   dpkg -s supervisor > /dev/null 2>&1 || \
   (apt-get update && apt-get install -y supervisor && apt-get clean)"
 


### PR DESCRIPTION
While trying to use https://github.com/amtrack/buildpack-gitlab to build a gitlab container, I got an error that I tracked down to /start not being executable. I couldn't see any other way that  the start script written here would be marked +x before the container tried to execute it, so I added this.

(If I missed something, don't hesitate to reject this -- I'm new to dokku. Thanks!)